### PR TITLE
Version query should be used as a prefix

### DIFF
--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -76,7 +76,7 @@ get_local_versions() {
   [[ -z $query ]] && query=$DEFAULT_QUERY
   $COMMAND versions \
     | sed -e 's/^\*//' -e 's/^\s*//' -e 's/ (set by.*$//' \
-    | grep -E "$query" \
+    | grep -E "^\s*$query" \
     | sort --version-sort
 }
 


### PR DESCRIPTION
Without this change, 'pyenv latest local 2.7' installs 'pypy2.7-6.0.0' on my system, since that's the 'latest' 2.7 python installed.