### PR TITLE
Use --skip-aliases and exclude versions containing /envs

### DIFF
--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -74,8 +74,9 @@ get_server_version() {
 get_local_versions() {
   local query=$1
   [[ -z $query ]] && query=$DEFAULT_QUERY
-  $COMMAND versions \
+  $COMMAND versions --skip-aliases \
     | sed -e 's/^\*//' -e 's/^\s*//' -e 's/ (set by.*$//' \
+    | grep -v "/envs" \
     | grep -E "^\s*$query" \
     | sort --version-sort
 }


### PR DESCRIPTION
This change excludes virtualenv and aliases when listing local versions.

Close #2