### PR TITLE
Improve error messages if version not found

### DIFF
--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -87,7 +87,7 @@ get_local_version() {
 
 print_version() {
     local version=$(get_$1_version $2)
-    [[ -z $version ]] && abort "This version is not found."
+    [[ -z $version ]] && abort "Version '$2' was not found."
     echo $version
 }
 
@@ -102,7 +102,7 @@ latest() {
                 ;;
             *)
                 version=$($getcmd $arg)
-                [[ -z $version ]] && abort "This version is not found."
+                [[ -z $version ]] && abort "Version '$arg' was not found."
                 new_args="$new_args $version"
                 ;;
         esac
@@ -110,7 +110,7 @@ latest() {
     done
     if [[ -z $version ]]; then
         version=$($getcmd)
-        [[ -z $version ]] && abort "This version is not found."
+        [[ -z $version ]] && abort "Version was not found."
         new_args="$new_args $version"
     fi
 

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -87,7 +87,7 @@ get_local_version() {
 
 print_version() {
     local version=$(get_$1_version $2)
-    [[ -z $version ]] && abort "Version '$2' was not found."
+    [[ -z $version ]] && abort "Version '$2' is not found."
     echo $version
 }
 
@@ -102,7 +102,7 @@ latest() {
                 ;;
             *)
                 version=$($getcmd $arg)
-                [[ -z $version ]] && abort "Version '$arg' was not found."
+                [[ -z $version ]] && abort "Version '$arg' is not found."
                 new_args="$new_args $version"
                 ;;
         esac
@@ -110,7 +110,7 @@ latest() {
     done
     if [[ -z $version ]]; then
         version=$($getcmd)
-        [[ -z $version ]] && abort "Version was not found."
+        [[ -z $version ]] && abort "Version is not found."
         new_args="$new_args $version"
     fi
 


### PR DESCRIPTION
I was using this in a Dockerfile like so:

  RUN pyenv latest install 2.7 \
      pyenv latest install 3.5 \
      pyenv latest install 3.6 \
      pyenv latest install 3.7 \
      pyenv latest global

Of course, that should have read:

  RUN pyenv latest install 2.7 && \
      pyenv latest install 3.5 && \
      pyenv latest install 3.6 && \
      pyenv latest install 3.7 && \
      pyenv latest global

Unfortunately that was difficult to figure out because all I saw was:

  pyenv: This version is not found.

Fix things by logging the version we're attempting to search for.