### PR TITLE
Update uninstall_not_latest() to be portable

### DIFF
--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -130,7 +130,7 @@ uninstall_not_latest() {
         esac
         shift 1
     done
-    for version in $(get_local_versions $version_prefix | head --lines=-1); do
+    for version in $(get_local_versions $version_prefix | sed '$ d'); do
         $COMMAND uninstall $new_args $version
     done
 }


### PR DESCRIPTION
BSD (MacOS) head command does not support negative line numbers. Replace
with comparable portable sed command. This addresses issue #10. 