### PR TITLE
Directly call *env commands to avoid hook path duplication

### DIFF
--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -74,7 +74,7 @@ version() {
 
 get_server_version() {
   local query=${1:-$DEFAULT_QUERY}
-  install_opts="--list"
+  local install_opts="--list"
   if [[ "$COMMAND" == "rbenv" ]]; then
     "$COMMAND"-install --help | grep -q -- --list-all \
       && install_opts="--list-all"
@@ -112,6 +112,7 @@ latest() {
     local getcmd=get_$1_version; shift 1
     local new_args
     local version
+    local arg
     for arg; do
         case "$arg" in
             -*)
@@ -136,6 +137,9 @@ latest() {
 }
 
 uninstall_not_latest() {
+    local arg
+    local new_args
+    local version_prefix
     for arg; do
         case "$arg" in
             -*)
@@ -147,6 +151,7 @@ uninstall_not_latest() {
         esac
         shift 1
     done
+    local version
     for version in $(get_local_versions "$version_prefix" | sed '$ d'); do
         "$COMMAND"-uninstall "$new_args" "$version"
     done

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -52,7 +52,7 @@ if [ "$1" = "--complete" ]; then
     else
         SUBCOMMAND=$1
         shift 1
-        $COMMAND $SUBCOMMAND --complete $*
+        "$COMMAND-$SUBCOMMAND" --complete $*
     fi
     exit
 fi
@@ -77,11 +77,11 @@ get_server_version() {
   [[ -z $query ]] && query=$DEFAULT_QUERY
   install_opts="--list"
   if [[ "$COMMAND" == "rbenv" ]]; then
-    $COMMAND install --help | grep -- --list-all 2>&1 > /dev/null \
+    "$COMMAND"-install --help | grep -- --list-all 2>&1 > /dev/null \
       && install_opts="--list-all"
   fi
 
-  $COMMAND install $install_opts 2> /dev/null \
+  "$COMMAND"-install $install_opts 2> /dev/null \
     | grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\.]rc|-alpha|-beta|[-\.]pre|-next|(a|b|c)[0-9]+$|snapshot|master|-nightly)" \
     | grep -E "^\s*${query/./\\.}\b" \
     | sed 's/^[[:space:]]*//' \
@@ -92,7 +92,7 @@ get_server_version() {
 get_local_versions() {
   local query=$1
   [[ -z $query ]] && query=$DEFAULT_QUERY
-  $COMMAND versions --skip-aliases \
+  "$COMMAND"-versions --skip-aliases \
     | sed -e 's/^\*//' -e 's/^[[:space:]]*//' -e 's/ (set by.*$//' \
     | grep -v "/envs" \
     | grep -E "^\s*$query" \
@@ -133,7 +133,7 @@ latest() {
     fi
 
     echo "Latest version is '$version'"
-    $COMMAND $SUBCOMMAND $new_args
+    "$COMMAND-$SUBCOMMAND" $new_args
 }
 
 uninstall_not_latest() {
@@ -149,17 +149,17 @@ uninstall_not_latest() {
         shift 1
     done
     for version in $(get_local_versions $version_prefix | sed '$ d'); do
-        $COMMAND uninstall $new_args $version
+        "$COMMAND"-uninstall $new_args $version
     done
 }
 
 update() {
     local version_type=$1; shift
     local mode=local
-    local now_version=$($COMMAND local 2> /dev/null)
+    local now_version=$("$COMMAND"-local 2> /dev/null)
     if [[ -z "$now_version" ]]; then
         mode=global
-        now_version=$($COMMAND global)
+        now_version=$("$COMMAND"-global)
     fi
     [[ "$now_version" == "system" ]] && abort "Curretly version is 'system'."
     case "$version_type" in
@@ -175,18 +175,18 @@ update() {
     esac
     local new_version=$(print_version server $query)
     echo "Latest version is '$new_version'"
-    $COMMAND install --skip-existing $new_version
-    $COMMAND $mode $new_version
+    "$COMMAND"-install --skip-existing $new_version
+    "$COMMAND-$mode" $new_version
 }
 
 shift 1
 case "$SUBCOMMAND" in
     "")
         version
-        $COMMAND help latest
+        "$COMMAND"-help latest
         ;;
     -h | --help)
-        $COMMAND help latest
+        "$COMMAND"-help latest
         ;;
     -v | --version)
         version

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -22,7 +22,7 @@
 #   update-minor            Update the minor version of the currently active version
 #   update-revision         Update the revision of the currently active version
 set -e
-[ -n "$PYENV_DEBUG" ] && set -b
+[[ -v PYENV_DEBUG ]] && set -b
 
 XXENV_LATEST_VERSION="0.2.1"
 DEFAULT_QUERY="[0-9]+"
@@ -59,7 +59,7 @@ fi
 
 abort() {
     {
-        if [ "$#" -eq 0 ]; then
+        if (($# == 0)); then
             cat -
         else
             echo "$COMMAND: $*"
@@ -73,8 +73,7 @@ version() {
 }
 
 get_server_version() {
-  local query=$1
-  [[ -z $query ]] && query=$DEFAULT_QUERY
+  local query=${1:-$DEFAULT_QUERY}
   install_opts="--list"
   if [[ "$COMMAND" == "rbenv" ]]; then
     "$COMMAND"-install --help | grep -- --list-all 2>&1 > /dev/null \
@@ -90,8 +89,7 @@ get_server_version() {
 }
 
 get_local_versions() {
-  local query=$1
-  [[ -z $query ]] && query=$DEFAULT_QUERY
+  local query=${1:-$DEFAULT_QUERY}
   "$COMMAND"-versions --skip-aliases \
     | sed -e 's/^\*//' -e 's/^[[:space:]]*//' -e 's/ (set by.*$//' \
     | grep -v "/envs" \

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -76,7 +76,7 @@ get_server_version() {
   local query=${1:-$DEFAULT_QUERY}
   install_opts="--list"
   if [[ "$COMMAND" == "rbenv" ]]; then
-    "$COMMAND"-install --help | grep -- --list-all 2>&1 > /dev/null \
+    "$COMMAND"-install --help | grep -q -- --list-all \
       && install_opts="--list-all"
   fi
 

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -159,7 +159,7 @@ update() {
         mode=global
         now_version=$("$COMMAND"-global)
     fi
-    [[ "$now_version" == "system" ]] && abort "Curretly version is 'system'."
+    [[ "$now_version" == "system" ]] && abort "Currently version is 'system'."
     case "$version_type" in
         major)
             local query=$(echo $now_version | sed -e 's/[0-9]\+\.[0-9]\+\.[0-9]\+$//')

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -52,7 +52,7 @@ if [ "$1" = "--complete" ]; then
     else
         SUBCOMMAND=$1
         shift 1
-        "$COMMAND-$SUBCOMMAND" --complete $*
+        "$COMMAND-$SUBCOMMAND" --complete "$@"
     fi
     exit
 fi
@@ -100,7 +100,7 @@ get_local_versions() {
 }
 
 get_local_version() {
-    get_local_versions $* | tail -1
+    get_local_versions "$@" | tail -1
 }
 
 print_version() {
@@ -192,19 +192,19 @@ case "$SUBCOMMAND" in
         version
         ;;
     -p | --print)
-        print_version server $*
+        print_version server "$@"
         ;;
     -P | --print-installed)
-        print_version local $*
+        print_version local "$@"
         ;;
     install)
-        latest server $*
+        latest server "$@"
         ;;
     uninstall)
-        uninstall_not_latest $*
+        uninstall_not_latest "$@"
         ;;
     global | local | prefix)
-        latest local $*
+        latest local "$@"
         ;;
     update-major)
         update major

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -102,9 +102,9 @@ get_local_version() {
 }
 
 print_version() {
-    local version=$(get_$1_version $2)
+    local version=$(get_"$1"_version "$2")
     [[ -z $version ]] && abort "Version '$2' is not found."
-    echo $version
+    echo "$version"
 }
 
 latest() {
@@ -117,7 +117,7 @@ latest() {
                 new_args="$new_args $arg"
                 ;;
             *)
-                version=$($getcmd $arg)
+                version=$($getcmd "$arg")
                 [[ -z $version ]] && abort "Version '$arg' is not found."
                 new_args="$new_args $version"
                 ;;
@@ -131,7 +131,7 @@ latest() {
     fi
 
     echo "Latest version is '$version'"
-    "$COMMAND-$SUBCOMMAND" $new_args
+    "$COMMAND-$SUBCOMMAND" "$new_args"
 }
 
 uninstall_not_latest() {
@@ -146,8 +146,8 @@ uninstall_not_latest() {
         esac
         shift 1
     done
-    for version in $(get_local_versions $version_prefix | sed '$ d'); do
-        "$COMMAND"-uninstall $new_args $version
+    for version in $(get_local_versions "$version_prefix" | sed '$ d'); do
+        "$COMMAND"-uninstall "$new_args" "$version"
     done
 }
 
@@ -162,19 +162,19 @@ update() {
     [[ "$now_version" == "system" ]] && abort "Currently version is 'system'."
     case "$version_type" in
         major)
-            local query=$(echo $now_version | sed -e 's/[0-9]\+\.[0-9]\+\.[0-9]\+$//')
+            local query=$(echo "$now_version" | sed -e 's/[0-9]\+\.[0-9]\+\.[0-9]\+$//')
             ;;
         minor)
-            local query=$(echo $now_version | sed -e 's/\.[0-9]\+\.[0-9]\+$//')
+            local query=$(echo "$now_version" | sed -e 's/\.[0-9]\+\.[0-9]\+$//')
             ;;
         revision)
-            local query=$(echo $now_version | sed -e 's/\.[0-9]\+$//')
+            local query=$(echo "$now_version" | sed -e 's/\.[0-9]\+$//')
             ;;
     esac
-    local new_version=$(print_version server $query)
+    local new_version=$(print_version server "$query")
     echo "Latest version is '$new_version'"
-    "$COMMAND"-install --skip-existing $new_version
-    "$COMMAND-$mode" $new_version
+    "$COMMAND"-install --skip-existing "$new_version"
+    "$COMMAND-$mode" "$new_version"
 }
 
 shift 1

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -110,18 +110,18 @@ print_version() {
 
 latest() {
     local getcmd=get_$1_version; shift 1
-    local new_args
+    local -a new_args
     local version
     local arg
     for arg; do
         case "$arg" in
             -*)
-                new_args="$new_args $arg"
+                new_args+=("$arg")
                 ;;
             *)
                 version=$($getcmd "$arg")
                 [[ -z $version ]] && abort "Version '$arg' is not found."
-                new_args="$new_args $version"
+                new_args+=("$version")
                 ;;
         esac
         shift 1
@@ -129,21 +129,21 @@ latest() {
     if [[ -z $version ]]; then
         version=$($getcmd)
         [[ -z $version ]] && abort "Version is not found."
-        new_args="$new_args $version"
+        new_args+=("$version")
     fi
 
     echo "Latest version is '$version'"
-    "$COMMAND-$SUBCOMMAND" "$new_args"
+    "$COMMAND-$SUBCOMMAND" "${new_args[@]}"
 }
 
 uninstall_not_latest() {
     local arg
-    local new_args
+    local -a new_args
     local version_prefix
     for arg; do
         case "$arg" in
             -*)
-                new_args="$new_args $arg"
+                new_args+=("$arg")
                 ;;
             *)
                 version_prefix=$arg
@@ -153,7 +153,7 @@ uninstall_not_latest() {
     done
     local version
     for version in $(get_local_versions "$version_prefix" | sed '$ d'); do
-        "$COMMAND"-uninstall "$new_args" "$version"
+        "$COMMAND"-uninstall "${new_args[@]}" "$version"
     done
 }
 

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -35,7 +35,7 @@ SUBCOMMAND="$1"
 # Provide nodenv completions
 # Provide goenv completions
 # Provide phpenv completions
-if [ "$1" = "--complete" ]; then
+if [[ $1 == --complete ]]; then
     shift 1
     if [[ -z $1 ]]; then
         echo install

--- a/bin/xxenv-latest
+++ b/bin/xxenv-latest
@@ -102,7 +102,8 @@ get_local_version() {
 }
 
 print_version() {
-    local version=$(get_"$1"_version "$2")
+    local version
+    version=$(get_"$1"_version "$2")
     [[ -z $version ]] && abort "Version '$2' is not found."
     echo "$version"
 }
@@ -154,24 +155,27 @@ uninstall_not_latest() {
 update() {
     local version_type=$1; shift
     local mode=local
-    local now_version=$("$COMMAND"-local 2> /dev/null)
+    local now_version
+    now_version=$("$COMMAND"-local 2> /dev/null)
     if [[ -z "$now_version" ]]; then
         mode=global
         now_version=$("$COMMAND"-global)
     fi
     [[ "$now_version" == "system" ]] && abort "Currently version is 'system'."
+    local query
     case "$version_type" in
         major)
-            local query=$(echo "$now_version" | sed -e 's/[0-9]\+\.[0-9]\+\.[0-9]\+$//')
+            query=$(echo "$now_version" | sed -e 's/[0-9]\+\.[0-9]\+\.[0-9]\+$//')
             ;;
         minor)
-            local query=$(echo "$now_version" | sed -e 's/\.[0-9]\+\.[0-9]\+$//')
+            query=$(echo "$now_version" | sed -e 's/\.[0-9]\+\.[0-9]\+$//')
             ;;
         revision)
-            local query=$(echo "$now_version" | sed -e 's/\.[0-9]\+$//')
+            query=$(echo "$now_version" | sed -e 's/\.[0-9]\+$//')
             ;;
     esac
-    local new_version=$(print_version server "$query")
+    local new_version
+    new_version=$(print_version server "$query")
     echo "Latest version is '$new_version'"
     "$COMMAND"-install --skip-existing "$new_version"
     "$COMMAND-$mode" "$new_version"


### PR DESCRIPTION
I noticed that any time I use `*env latest install`, any `after_install` hooks were being called twice.

Eventually, I found that [this](https://github.com/cehoffman/luaenv/blob/3ef7626fded7042a0363a67d71153868f7075b8f/libexec/luaenv#L78-L87) (would apply to any `$COMMAND`, but I'm using luaenv as an example) in combination with the fact that xxenv-latest is calling the install commands like `$COMMAND install` is causing the hook directories to be added twice. The first time, when `*env latest ...` is called by the user and then again when xxenv-latest calls the install command.

Since *env sets up PATH such that the subcommands can be used directly, it makes more sense to call them like `$COMMAND-$SUBCOMMAND`. This ensures the hook PATH is only altered once.

I went ahead and changed every call (not just install) to be consistent, but I don't know that it would affect others, since {before,after}_install seem to be the only hooks. There could be more in the future, and this would ensure all the commands have a clean environment.

Kind of related, but would you be open to me adding some unit testing in another PR?